### PR TITLE
Demo data for pandemic reports

### DIFF
--- a/controllers/database/pandemic_whistle.py
+++ b/controllers/database/pandemic_whistle.py
@@ -63,14 +63,14 @@ class PandemicWhistle(db.Model):
         if reported_date is None:
             self.reported_date = datetime.now()
         else:
-            self.reported_date = datetime.fromtimestamp(reported_date)
+            self.reported_date = datetime.fromtimestamp(int(float(reported_date)))
         self.hash = hash
         self.facility_type = facility_type
         self.district_state = district_state
         self.district = district
         self.reporter_type = reporter_type
 
-        self.surgical_masks = surgical_masks=False
+        self.surgical_masks = surgical_masks
         self.n95_masks = n95_masks
         self.papr_hoods = papr_hoods
         self.non_sterile_gloves = non_sterile_gloves

--- a/manage.py
+++ b/manage.py
@@ -8,6 +8,7 @@ from app import create_app
 
 import scripts.load_zips
 import scripts.demo_data
+import scripts.pandemic_demo_data
 
 app = create_app()
 manager = Manager(app)
@@ -16,6 +17,11 @@ class DemoDataCommand(Command):
 
     def run(self):
         scripts.demo_data.load()
+
+class PandemicDemoDataCommand(Command):
+
+    def run(self):
+        scripts.pandemic_demo_data.load()
 
 class ServerCommand(Command):
 
@@ -44,6 +50,7 @@ manager.add_command('db', MigrateCommand)
 manager.add_command('serve', ServerCommand())
 manager.add_command('zips', ZipLoaderCommand())
 manager.add_command('demo', DemoDataCommand())
+manager.add_command('pdemo', PandemicDemoDataCommand())
 manager.add_command('test', TestCommand())
 
 manager.run()

--- a/scripts/pandemic_demo_data.py
+++ b/scripts/pandemic_demo_data.py
@@ -1,0 +1,118 @@
+import uuid
+import random
+from datetime import datetime, timedelta
+
+from extensions import db
+from controllers.database.whistle import FacilityType, ReporterType
+from controllers.database.pandemic_whistle import PandemicWhistle
+
+def get_state():
+    states = ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+              'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
+              'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
+              'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+              'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY']
+    return states[random.randint(0, len(states) - 1)]
+
+def get_district_by_state(state):
+    districts_by_state = { 
+        'AL': 7, 'AK': 1, 'AZ': 9, 'AR': 4, 'CA': 53,
+        'CO': 7, 'CT': 5, 'DE': 1, 'FL': 27, 'GA': 14,
+        'HI': 2, 'ID': 2, 'IL': 18, 'IN': 9, 'IA': 4,
+        'KS': 4, 'KY': 6, 'LA': 6, 'ME': 2, 'MD': 8,
+        'MA': 9, 'MI': 14, 'MN': 8, 'MS': 4, 'MO': 8,
+        'MT': 1, 'NE': 3, 'NV': 4, 'NH': 2, 'NJ': 12,
+        'NM': 3, 'NY': 27, 'NC': 13, 'ND': 1, 'OH': 16,
+        'OK': 5, 'OR': 5, 'PA': 18, 'RI': 2, 'SC': 7,
+        'SD': 1, 'TN': 9, 'TX': 36, 'UT': 4, 'VT': 1,
+        'VA': 11, 'WA': 10, 'WV': 3, 'WI': 8, 'WY': 1
+    }
+    return random.randint(1, districts_by_state.get(state, 1))
+
+def get_facility_type():
+    types = [
+        FacilityType.pre_hospital,
+        FacilityType.hospital,
+        FacilityType.nursing_home,
+        FacilityType.er,
+        FacilityType.urgent_care
+    ]
+    return types[random.randint(0, len(types) - 1)]
+
+def get_reporter_type():
+    types = [
+        ReporterType.emt,
+        ReporterType.paramedic,
+        ReporterType.rn,
+        ReporterType.apn,
+        ReporterType.lpn,
+        ReporterType.cna,
+        ReporterType.rt,
+        ReporterType.physician,
+        ReporterType.pa]
+    return types[random.randint(0, len(types) - 1)]
+
+def get_hash():
+    return 'demo' + str(uuid.uuid4())[:24]
+
+def get_reported_date():
+    days_removed = random.randint(0, 60)
+    return datetime.today() - timedelta(days=days_removed)
+
+def get_willing():
+    return random.randint(0, 2)
+
+def get_shortages():
+    shortages = {}
+
+    # get number we should try to get
+    shortage_count = random.randint(0,4)
+    options = [
+        'surgical_masks', 'n95_masks', 'papr_hoods',
+        'non_sterile_gloves', 'isolation_gowns', 'face_shields',
+        'oxygen', 'sedatives', 'narcotic_analgesics',
+        'paralytics', 'icu_beds', 'icu_trained_nurses', 'ventilators'
+    ]
+
+    for x in range(shortage_count):
+        shortages[options[random.randint(0, len(options) - 1)]] = True
+
+    return shortages
+
+def get_testing():
+    testing = {}
+
+    # has no result option
+    if random.choice([True, False]):
+        value = random.choice(['test_none', 'test_tried', 'test_no_result'])
+        testing[value] = True
+    else:
+        # has swab test
+        if random.choice([True, False]):
+            value = random.choice(['test_swab_neg', 'test_swab_pos'])
+            testing[value] = True
+
+        # has antibody test
+        if random.choice([True, False]):
+            value = random.choice(['test_anti_neg', 'test_anti_pos'])
+            testing[value] = True
+    
+    return testing
+
+def load():
+    for x in range(500):
+        state = get_state()
+        data = {
+            'hash': get_hash(),
+            'facility_type': get_facility_type(),
+            'reporter_type': get_reporter_type(),
+            'district_state': state,
+            'district': get_district_by_state(state),
+            'reported_date': get_reported_date(),
+            'willing_to_report': get_willing()
+        }
+        data.update(get_shortages())
+        data.update(get_testing())
+        report = PandemicWhistle(data)
+        db.session.add(report)
+        db.session.commit()

--- a/scripts/pandemic_demo_data.py
+++ b/scripts/pandemic_demo_data.py
@@ -57,7 +57,9 @@ def get_hash():
 
 def get_reported_date():
     days_removed = random.randint(0, 60)
-    return datetime.today() - timedelta(days=days_removed)
+    today = datetime.today()
+    just_today = datetime(today.year, today.month, today.day)
+    return int((just_today - timedelta(days=days_removed)).timestamp())
 
 def get_willing():
     return random.randint(0, 2)
@@ -66,7 +68,7 @@ def get_shortages():
     shortages = {}
 
     # get number we should try to get
-    shortage_count = random.randint(0,4)
+    shortage_count = random.randint(0,5)
     options = [
         'surgical_masks', 'n95_masks', 'papr_hoods',
         'non_sterile_gloves', 'isolation_gowns', 'face_shields',
@@ -100,6 +102,11 @@ def get_testing():
     return testing
 
 def load():
+    db.session.query(PandemicWhistle).filter(
+        PandemicWhistle.hash.like('demo%')
+    ).delete(synchronize_session=False)
+    db.session.commit()
+
     for x in range(500):
         state = get_state()
         data = {
@@ -113,6 +120,6 @@ def load():
         }
         data.update(get_shortages())
         data.update(get_testing())
-        report = PandemicWhistle(data)
+        report = PandemicWhistle(**data)
         db.session.add(report)
         db.session.commit()


### PR DESCRIPTION
Adds a demo script to generate 500 records in the pandemic_whistles table. These should be logically structured to match the options in the frontend.